### PR TITLE
[RFR]remove ebsco_widget_connection shortcode

### DIFF
--- a/wp-content/themes/portail/views/page-layout.twig
+++ b/wp-content/themes/portail/views/page-layout.twig
@@ -46,7 +46,6 @@
                         <div class="language">
                             {{language_switcher}}
                         </div>
-                        {{ "[ebsco_widget_connection]"|shortcodes }}
                     </div>
                 </div>
             </header>
@@ -59,7 +58,7 @@
                             <ul class="menu">
                                 <div class="navHeader">
                                     <img src="{{theme.uri}}/images/{{__('News', 'bibcnrs')}}.png" alt="">
-                                </div>                    
+                                </div>
                                 {% for item in principal.get_items %}
                                 <li class="nav-main-item  {{item.classes | join(' ')}}">
                                     <a class="nav-main-link" href="{{item.get_link}}">


### PR DESCRIPTION
https://trello.com/c/wNVnbH9E/117-025bibcnrs-d%C3%A9placer-lc%C3%B4ne-mon-profil-au-niveau-de-lutilisateur-et-connexion

- [x] remove connection shortcode disabling the connection portal
https://github.com/BibCnrs/EBSCO-widget/pull/197 will display connection button inside the widget when no portal

So if the shortcode is readded later the connection button will be moved outside the widget to the shortcode.