### PR TITLE
fix (translation): Adding chevron in english translation

### DIFF
--- a/packages/front/src/app/shared/locales/common/en.ts
+++ b/packages/front/src/app/shared/locales/common/en.ts
@@ -108,7 +108,7 @@ const en: Common = {
 				present: "Present",
 				links: 'Access to "{{ title }}" article',
 				pdf: "Pdf access",
-				seeMore: "See more",
+				seeMore: "See more >",
 				seeMoreAbout: "See more about {{ title }}",
 				abstract: "Abstract",
 				contributors: "Contributors",


### PR DESCRIPTION
Adding chevron in english translation to be as same as french content