### PR TITLE
Feat(platform): Add matomo tracking on platform click

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Problem
+
+## Solution
+
+## How to Test

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -144,7 +144,7 @@ services:
       - ./../storage/postgresql:/var/lib/postgresql/data
       - ./../storage/backups:/backups
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-U", "postgres", "-d", "bibcnrs"]
+      test: ["CMD-SHELL", "pg_isready"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -144,7 +144,7 @@ services:
       - ./../storage/postgresql:/var/lib/postgresql/data
       - ./../storage/backups:/backups
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready", "-U", "postgres", "-d", "bibcnrs"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/packages/front/src/app/pages/search/database/DatabaseItem.tsx
+++ b/packages/front/src/app/pages/search/database/DatabaseItem.tsx
@@ -2,12 +2,19 @@ import { Card, CardContent, Link, Stack, Tooltip } from "@mui/material";
 import BookmarkButton from "../../../components/element/button/BookmarkButton";
 import DatabaseIcons from "../../../components/element/icon/DatabaseIcons";
 import { useBibContext } from "../../../context/BibContext";
+import { useMatomo } from "../../../shared/matomo";
 import type { DatabaseItemProps } from "../../../shared/types/data.types";
 
 export function DatabaseItem(props: DatabaseItemProps) {
 	const {
 		session: { user },
 	} = useBibContext();
+	const { trackEvent } = useMatomo();
+
+	const handleClick = () => {
+		trackEvent("Database", "click", props.name, props.id);
+	};
+
 	return (
 		<Tooltip
 			title={props.text}
@@ -43,6 +50,7 @@ export function DatabaseItem(props: DatabaseItemProps) {
 								href={props.url}
 								target="_blank"
 								rel="noopener noreferrer"
+								onClick={handleClick}
 							>
 								{props.name}
 							</Link>


### PR DESCRIPTION
## Problem

Bib Admins want to track platform clicks

## Solution

Add matomo tracking to platforms

## How to Test

Create an account on matomo cloud
Configure the following environment variables to `docker-compose.dev.env`

```sh
MATOMO_TRACKER_URL=https://{env_domain}.matomo.cloud/matomo.php
MATOMO_SCRIPT_URL=https://cdn.matomo.cloud/{env_domain}.matomo.cloud/matomo.js
MATOMO_SITE_ID=1
```
