### PR TITLE
Fix(platforms): Show filters without results as disabled instead of hiding them

### DIFF
--- a/packages/e2e/tests/navigation.spec.ts
+++ b/packages/e2e/tests/navigation.spec.ts
@@ -5,37 +5,50 @@ test("search bar navigation", async ({ page }) => {
 	await janusLogin(page);
 	await page.goto("/");
 
-	await expect(page.getByText("Articles")).toBeVisible();
-	await expect(page.getByText("Revues, ouvrages")).toBeVisible();
-	await expect(page.getByText("Plateformes")).toBeVisible();
-	await expect(page.getByText("Données de recherche")).toBeVisible();
+	await expect(page.getByRole("link", { name: "Articles" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Revues, ouvrages" }),
+	).toBeVisible();
+	await expect(page.getByRole("link", { name: "Plateformes" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Données de recherche" }),
+	).toBeVisible();
 
-	await page.getByText("Articles").click();
+	await page.getByRole("link", { name: "Articles" }).click();
 	await page.waitForURL("/article?*");
-	await expect(page.getByText("Articles")).toBeVisible();
-	await expect(page.getByText("Articles")).toHaveAttribute(
+	await expect(page.getByRole("link", { name: "Articles" })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Articles" })).toHaveAttribute(
 		"aria-current",
 		"page",
 	);
-	await expect(page.getByText("Revues, ouvrages")).toBeVisible();
-	await expect(page.getByText("Plateformes")).toBeVisible();
-	await expect(page.getByText("Données de recherche")).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Revues, ouvrages" }),
+	).toBeVisible();
+	await expect(page.getByRole("link", { name: "Plateformes" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Données de recherche" }),
+	).toBeVisible();
 
-	await page.getByText("Revues, ouvrages").click();
+	await page.getByRole("link", { name: "Revues, ouvrages" }).click();
 	await page.waitForURL("/publication?*");
-	await expect(page.getByText("Articles")).toBeVisible();
-	await expect(page.getByText("Revues, ouvrages")).toBeVisible();
-	await expect(page.getByText("Revues, ouvrages")).toHaveAttribute(
-		"aria-current",
-		"page",
-	);
-	await expect(page.getByText("Plateforme")).toBeVisible();
-	await expect(page.getByText("Données de recherche")).toBeVisible();
+	await expect(page.getByRole("link", { name: "Articles" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Revues, ouvrages" }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Revues, ouvrages" }),
+	).toHaveAttribute("aria-current", "page");
+	await expect(page.getByRole("link", { name: "Plateforme" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Données de recherche" }),
+	).toBeVisible();
 
-	await page.getByText("Plateforme").click();
+	await page.getByRole("link", { name: "Plateforme" }).click();
 	await page.waitForURL("/database");
-	await expect(page.getByText("Articles")).toBeVisible();
-	await expect(page.getByText("Revues, ouvrages")).toBeVisible();
+	await expect(page.getByRole("link", { name: "Articles" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Revues, ouvrages" }),
+	).toBeVisible();
 	await expect(
 		page.getByText("Plateformes", {
 			exact: true,
@@ -46,16 +59,21 @@ test("search bar navigation", async ({ page }) => {
 			exact: true,
 		}),
 	).toHaveAttribute("aria-current", "page");
-	await expect(page.getByText("Données de recherche")).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Données de recherche" }),
+	).toBeVisible();
 
-	await page.getByText("Données de recherche").click();
+	await page.getByRole("link", { name: "Données de recherche" }).click();
 	await page.waitForURL("/research-data?*");
-	await expect(page.getByText("Articles")).toBeVisible();
-	await expect(page.getByText("Revues, ouvrages")).toBeVisible();
-	await expect(page.getByText("Plateformes")).toBeVisible();
-	await expect(page.getByText("Données de recherche")).toBeVisible();
-	await expect(page.getByText("Données de recherche")).toHaveAttribute(
-		"aria-current",
-		"page",
-	);
+	await expect(page.getByRole("link", { name: "Articles" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Revues, ouvrages" }),
+	).toBeVisible();
+	await expect(page.getByRole("link", { name: "Plateformes" })).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Données de recherche" }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("link", { name: "Données de recherche" }),
+	).toHaveAttribute("aria-current", "page");
 });

--- a/packages/e2e/tests/page-platform.spec.ts
+++ b/packages/e2e/tests/page-platform.spec.ts
@@ -79,3 +79,36 @@ test("filter platforms ", async ({ page }) => {
 		}
 	}
 });
+
+test("filter platforms updates filters result", async ({ page }) => {
+	await page.goto("/database");
+
+	const filter = page.getByRole("combobox", {
+		name: "Recherche",
+	});
+
+	await expect(filter).toBeVisible({
+		timeout: 10000,
+	});
+
+	const databases = page.getByLabel("Plateformes", { exact: true });
+	await expect(databases).toBeVisible({
+		timeout: 10000,
+	});
+
+	const searchButton = page.getByRole("search");
+	await expect(searchButton).toBeVisible({
+		timeout: 10000,
+	});
+
+	await filter.fill("ADS");
+	await searchButton.click();
+
+	await expect(databases.locator("[role=listitem]")).toHaveCount(1);
+
+	await expect(page.getByLabel("Accès Ouvert (1)")).toBeVisible();
+	await expect(page.getByLabel("Accès Ouvert (1)")).not.toBeDisabled();
+
+	await expect(page.getByLabel("Complétude: 100% (0)")).toBeVisible();
+	await expect(page.getByLabel("Complétude: 100% (0)")).toBeDisabled();
+});

--- a/packages/front/src/app/pages/search/database/FilterTab.tsx
+++ b/packages/front/src/app/pages/search/database/FilterTab.tsx
@@ -102,18 +102,13 @@ export default function FilterTab({
 					(item) => item.section === section && getLabelCount(item) > 0,
 				);
 
-				if (filteredItems.length === 0) {
-					return null;
-				}
 				return (
 					<Stack key={section} mb={1}>
 						<FormLabel component="legend" sx={{ fontWeight: 700 }}>
 							{t(`pages.database.filters.${section}`)}
 						</FormLabel>
 						{filters
-							.filter(
-								(item) => item.section === section && getLabelCount(item) > 0,
-							)
+							.filter((item) => item.section === section)
 							.map((filter, index) => (
 								<FormControlLabel
 									key={`${filter.props}-${index}`}
@@ -121,6 +116,7 @@ export default function FilterTab({
 										<Checkbox
 											checked={filter.value}
 											onChange={() => handleChange(filter)}
+											disabled={getLabelCount(filter) === 0}
 										/>
 									}
 									label={`${getLabel(filter)} (${getLabelCount(filter)})`}


### PR DESCRIPTION
## Problem

Users are lost when search filters are hidden when they have no result

## Solution

Alwas show filters but disable them if they have no result

## How to Test

Go to the platform page and filter values


https://github.com/user-attachments/assets/65a6a041-0840-4d25-981f-d6583a141381

