### PR TITLE
Fix(favorites): Update results count when a query is provided

### DIFF
--- a/packages/e2e/tests/favorites.spec.ts
+++ b/packages/e2e/tests/favorites.spec.ts
@@ -171,3 +171,26 @@ test("Show / Hide favorites on home page", async ({ page }) => {
 
 	await janusLogout(page);
 });
+
+test("Filter items", async ({ page }) => {
+	const cnrs = () => page.getByRole("listitem", { name: /www.cnrs.fr/i });
+	const ins2i = () =>
+		page.getByRole("listitem", { name: /www.ins2i.cnrs.fr/i });
+
+	await janusLogin(page);
+	await goToFavorites(page);
+	await expect(cnrs()).toBeVisible();
+	await expect(ins2i()).toBeVisible();
+
+	await page.getByPlaceholder("Rechercher dans mes favoris").fill("CNRS");
+	await page.getByPlaceholder("Rechercher dans mes favoris").press("Enter");
+	await expect(cnrs()).toBeVisible();
+	await expect(ins2i()).not.toBeVisible();
+
+	await page.getByPlaceholder("Rechercher dans mes favoris").fill("");
+	await page.getByPlaceholder("Rechercher dans mes favoris").press("Enter");
+	await expect(cnrs()).toBeVisible();
+	await expect(ins2i()).toBeVisible();
+
+	await janusLogout(page);
+});

--- a/packages/front/src/app/pages/user/favourite/Favourite.tsx
+++ b/packages/front/src/app/pages/user/favourite/Favourite.tsx
@@ -75,7 +75,9 @@ const Favourite = () => {
 	};
 
 	const hasFilter = useMemo(() => {
-		return Object.values(filters).some((filter) => filter != null);
+		return Object.values(filters).some(
+			(filter) => filter != null && filter !== "",
+		);
 	}, [filters]);
 
 	useEffect(() => {
@@ -88,6 +90,15 @@ const Favourite = () => {
 		}
 	}, [filters]);
 
+	const _filterByTitle = useCallback(
+		(title: string) => {
+			return (
+				filters.title != null && !title.toLowerCase().includes(filters.title)
+			);
+		},
+		[filters.title],
+	);
+
 	const filterFavoriteResource = useCallback(
 		(resources: FavouriteResourceDataType[]) => {
 			if (!hasFilter) {
@@ -95,10 +106,7 @@ const Favourite = () => {
 			}
 
 			return resources.filter((favourite) => {
-				if (
-					filters.title != null &&
-					!favourite.title.toLowerCase().includes(filters.title)
-				) {
+				if (_filterByTitle(favourite.title)) {
 					return false;
 				}
 
@@ -114,7 +122,7 @@ const Favourite = () => {
 				);
 			});
 		},
-		[filters, hasFilter],
+		[filters, hasFilter, _filterByTitle],
 	);
 
 	const filteredFavouriteResources = filterFavoriteResource(favouriteResources);
@@ -146,17 +154,28 @@ const Favourite = () => {
 								{t("pages.favourite.filters.title")}
 							</Typography>
 
-							{BOOLEAN_FILTERS.map((key) => (
-								<FormControlLabel
-									key={key}
-									control={<Checkbox checked={filters[key] === true} />}
-									label={t(`pages.favourite.filters.${key}`, {
-										count: allFavourites.filter(({ source }) => source === key)
-											.length,
-									})}
-									onChange={() => handleFilter(key)}
-								/>
-							))}
+							{BOOLEAN_FILTERS.map((key) => {
+								const count = allFavourites.filter(
+									({ title, source }) =>
+										source === key && !_filterByTitle(title),
+								).length;
+
+								return (
+									<FormControlLabel
+										key={key}
+										control={
+											<Checkbox
+												checked={filters[key] === true}
+												disabled={count === 0}
+											/>
+										}
+										label={t(`pages.favourite.filters.${key}`, {
+											count,
+										})}
+										onChange={() => handleFilter(key)}
+									/>
+								);
+							})}
 							<Button
 								color="error"
 								sx={{


### PR DESCRIPTION
## Problem

1. When filtering favorites, the update count was not updated
2. It was possible to have no result when selecting a filter with no items

## Solution

1. Update result count for filters when a search is provided
2. Disable filters when no result matches search

## How to Test

Go to favorites and filter them


https://github.com/user-attachments/assets/9cfec0d6-5e3e-449d-9782-0bf80f71b731

