### PR TITLE
Search onchange throttle

### DIFF
--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -38,6 +38,7 @@
 	"devDependencies": {
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/react": "^16.0.1",
+		"@testing-library/user-event": "^14.5.2",
 		"@types/react": "^18.3.5",
 		"@types/react-dom": "^18.3.0",
 		"@vitejs/plugin-react": "^4.3.1",

--- a/packages/front/src/app/components/page/searchbar/SearchBar.spec.tsx
+++ b/packages/front/src/app/components/page/searchbar/SearchBar.spec.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BrowserRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { BibContextProvider } from "../../../context/BibContext";
+import SearchBar from "./SearchBar";
+
+describe("SearchBar", () => {
+	it("should call onSearch with input value only once after user has stopped typing when autocomplete is disabled", async () => {
+		const onSearch = vi.fn();
+		const client = new QueryClient();
+		render(
+			<QueryClientProvider client={client}>
+				<BrowserRouter>
+					<BibContextProvider>
+						<SearchBar
+							onSearch={onSearch}
+							placeholder="placeholder"
+							value=""
+							disableAutocomplete
+						/>
+					</BibContextProvider>
+				</BrowserRouter>
+			</QueryClientProvider>,
+		);
+
+		expect(onSearch).toBeCalledTimes(0);
+
+		const input = screen.getByPlaceholderText("placeholder");
+		await userEvent.type(input, "hello");
+		await userEvent.type(input, " ");
+		await userEvent.type(input, "there");
+		expect(onSearch).toBeCalledTimes(0);
+		await new Promise<void>((resolve) => {
+			setTimeout(() => {
+				resolve();
+			}, 500);
+		});
+		expect(onSearch).toBeCalledTimes(1);
+		expect(onSearch).toBeCalledWith("hello there");
+	});
+
+	it("should call onSearch onBlur instead when autocomplete is enabled", async () => {
+		const onSearch = vi.fn();
+		const client = new QueryClient();
+		render(
+			<QueryClientProvider client={client}>
+				<BrowserRouter>
+					<BibContextProvider>
+						<SearchBar
+							onSearch={onSearch}
+							placeholder="placeholder"
+							value=""
+							disableAutocomplete={false}
+						/>
+					</BibContextProvider>
+				</BrowserRouter>
+			</QueryClientProvider>,
+		);
+
+		expect(onSearch).toBeCalledTimes(0);
+
+		const input = screen.getByPlaceholderText("placeholder");
+		await userEvent.type(input, "hello");
+		await userEvent.type(input, " ");
+		await userEvent.type(input, "there");
+		expect(onSearch).toBeCalledTimes(0);
+		await new Promise<void>((resolve) => {
+			setTimeout(() => {
+				resolve();
+			}, 500);
+		});
+		expect(onSearch).toBeCalledTimes(0);
+		input.blur();
+		expect(onSearch).toBeCalledTimes(1);
+		expect(onSearch).toHaveBeenCalledWith("hello there");
+	});
+
+	it("should also call onSearch when clicking search button", async () => {
+		const onSearch = vi.fn();
+		const client = new QueryClient();
+		render(
+			<QueryClientProvider client={client}>
+				<BrowserRouter>
+					<BibContextProvider>
+						<SearchBar
+							onSearch={onSearch}
+							placeholder="placeholder"
+							value=""
+							disableAutocomplete={false}
+						/>
+					</BibContextProvider>
+				</BrowserRouter>
+			</QueryClientProvider>,
+		);
+
+		expect(onSearch).toBeCalledTimes(0);
+
+		const input = screen.getByPlaceholderText("placeholder");
+		await userEvent.type(input, "hello");
+		await userEvent.type(input, " ");
+		await userEvent.type(input, "there");
+		expect(onSearch).toBeCalledTimes(0);
+		screen.getByRole("search").click();
+		expect(onSearch).toBeCalledTimes(1);
+		expect(onSearch).toHaveBeenCalledWith("hello there");
+	});
+});

--- a/packages/front/src/app/components/page/searchbar/SearchBar.tsx
+++ b/packages/front/src/app/components/page/searchbar/SearchBar.tsx
@@ -170,6 +170,7 @@ const SearchBar = ({
 						inputValue={value}
 						value={autocompleteValue}
 						onChange={handleAutocompleteChange}
+						onBlur={() => onSearch(value)}
 						onInputChange={handleChange}
 						onKeyDown={inputKeyDown}
 						renderInput={(params) => (

--- a/packages/front/src/app/components/page/searchbar/SearchBar.tsx
+++ b/packages/front/src/app/components/page/searchbar/SearchBar.tsx
@@ -60,6 +60,14 @@ const SearchBar = ({
 
 	const debounceValue = useDebounce(value, 375);
 
+	useEffect(() => {
+		if (!disableAutocomplete) {
+			return;
+		}
+		const timeoutId = setTimeout(() => onSearch(value), 500);
+		return () => clearTimeout(timeoutId);
+	}, [onSearch, value, disableAutocomplete]);
+
 	// biome-ignore lint/suspicious/noExplicitAny: Need to type after marmelab's mission
 	const { data } = useQuery<string[], any, string[], any>({
 		queryKey: ["search-bar", debounceValue],

--- a/packages/front/src/test/setup.ts
+++ b/packages/front/src/test/setup.ts
@@ -1,5 +1,7 @@
+import { cleanup } from "@testing-library/react";
 import { beforeEach, vi } from "vitest";
 
 beforeEach(async () => {
 	vi.restoreAllMocks();
+	cleanup();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,6 +446,7 @@ __metadata:
     "@tanstack/react-query-devtools": "npm:^5.55.4"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:^16.0.1"
+    "@testing-library/user-event": "npm:^14.5.2"
     "@types/md5": "npm:^2.3.5"
     "@types/react": "npm:^18.3.5"
     "@types/react-dom": "npm:^18.3.0"
@@ -2154,6 +2155,15 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/67d05dec5ad5a2e6f92b6a3234af785435c7bb62bdbf12f3bfc89c9bca0c871a189e88c4ba023ed4cea504704c87c6ac7e86e24a3962df6c521ae89b62f48ff7
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.5.2":
+  version: 14.5.2
+  resolution: "@testing-library/user-event@npm:14.5.2"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10c0/68a0c2aa28a3c8e6eb05cafee29705438d7d8a9427423ce5064d44f19c29e89b5636de46dd2f28620fb10abba75c67130185bbc3aa23ac1163a227a5f36641e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Search di not trigger unless user specifically choose an autocomplete option, pressed enter or cluicked on the search button

## Solution
- trigger search on blur when autocomplete is activated
- trigger search when user stopped typing when autocomplete is deactivated 

## How to Test

- Search on article page, blur input without selecting an autocomplete option => the search should trigger
- Search on platform page (no autocomplete) type a search, the search should trigger automatically but only after you stopped typing (half a second inactivity)
