### PR TITLE
prefix with publication title when adding sub link to favorite

### DIFF
--- a/packages/front/src/app/pages/search/publication/PublicationTitle.tsx
+++ b/packages/front/src/app/pages/search/publication/PublicationTitle.tsx
@@ -165,7 +165,7 @@ export function PublicationTitle({
 									{user ? (
 										<BookmarkButton
 											className="table-bookmark-button"
-											title={`${value.name} - ${getCoverage(value.coverage)}`}
+											title={`${publication.title} : ${value.name} - ${getCoverage(value.coverage)}`}
 											url={value.url}
 											source="publication"
 										/>


### PR DESCRIPTION
## Problem

sub publication name was incomplete when displayed in favorite

## Solution

prefix the publication name with the publication title

## How to Test

- go to Journals, books mpage
- Search for aids and behavior
- bookmark the 2 sub ling of the response
- go in favorite, and check that that the favorite title include both the pubication and the sub link label

## Preview

![image](https://github.com/user-attachments/assets/39788c91-0cf0-4056-ae58-815d8a609ba6)
