### PR TITLE
Fix(ops): Add postgres port and remove postgres role logs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -140,6 +140,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=S3cr3t
       - POSTGRES_DB=bibcnrs
+      - PGUSER=postgres
     volumes:
       - ./../storage/postgresql:/var/lib/postgresql/data
       - ./../storage/backups:/backups

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -114,11 +114,14 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
       PGDATA: /var/lib/postgresql/data/pgdata
+      PGUSER: ${POSTGRES_USER}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5
+    ports:
+      - "60000:5432"
     volumes:
       - ./../storage/backups:/backups
       - ./../storage/postgresql:/var/lib/postgresql/data/pgdata


### PR DESCRIPTION
## Problem

- Postres was not exposed
- `FATAL: role "root" does not exist` was logged to database output

## Solution

- Expose postgres to port `60000`
- Add `PGUSER` env to db container
